### PR TITLE
Add support for the -exclude flag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -145,6 +145,7 @@
     "cobracli",
     "matcher",
     "pkgpath",
+    "signals",
     "specdir",
   ]
   revision = "23395ebeee5df1083443a6261e5f674a76af91b6"
@@ -230,6 +231,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9a2105cdcb9b0906c3683226f03caa59c47f80a7b856ba0757d6f7eea9c99b4c"
+  inputs-digest = "f61167a81c9bb2c72083bb8379400dc5d0effb38d9fab35cc96b9597623dac88"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/errcheck/config/internal/v0/config.go
+++ b/errcheck/config/internal/v0/config.go
@@ -20,7 +20,8 @@ import (
 )
 
 type Config struct {
-	Ignore []string `yaml:"ignore,omitempty"`
+	Ignore  []string `yaml:"ignore,omitempty"`
+	Exclude []string `yaml:"exclude,omitempty"`
 }
 
 func UpgradeConfig(cfgBytes []byte) ([]byte, error) {

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -110,6 +110,35 @@ Finished errcheck
 `,
 			},
 			{
+				Name: "errcheck uses exclude configuration",
+				Specs: []gofiles.GoFileSpec{
+					{
+						RelPath: "foo.go",
+						Src: `package foo
+
+import "os"
+
+func Foo() {
+	os.Getwd()
+}
+`,
+					},
+				},
+				ConfigFiles: map[string]string{
+					"godel/config/godel.yml": godelYML,
+					"godel/config/check-plugin.yml": `
+checks:
+  errcheck:
+    config:
+      exclude:
+        - os.Getwd
+`,
+				},
+				WantOutput: `Running errcheck...
+Finished errcheck
+`,
+			},
+			{
 				Name: "unchecked error from inner directory",
 				Specs: []gofiles.GoFileSpec{
 					{
@@ -204,7 +233,7 @@ checks:
 				},
 			},
 			{
-				Name: `legacy configuration with args other than "ignore" fails`,
+				Name: `legacy configuration with unknown args fails`,
 				ConfigFiles: map[string]string{
 					"godel/config/check.yml": `
 checks:


### PR DESCRIPTION
Excludes are specified in the configuration file, and the expected file
for errcheck is created on disk as needed. The upgrader attempts to read
the existing file for configurations that use it.

This also changes the behavior of the ignore flag to join each argument
with a comma, since errcheck only accepts a single argument for this
flag. This shouldn't break existing users, as any project specifying
multiple patterns was already broken.

Fixes #15.