### PR TITLE
Remove package path prefix trimming logic

### DIFF
--- a/errcheck/creator/creator.go
+++ b/errcheck/creator/creator.go
@@ -103,10 +103,6 @@ func (c *postActionChecker) Check(pkgPaths []string, projectDir string, stdout i
 	if c.action != nil {
 		defer c.action()
 	}
-	// trim "./" prefixes to support package path formats for Go modules
-	for i := range pkgPaths {
-		pkgPaths[i] = strings.TrimPrefix(pkgPaths[i], "./")
-	}
 	c.Checker.Check(pkgPaths, projectDir, stdout)
 }
 


### PR DESCRIPTION
The logic introduced issues in cases where a relative package had
the same name as a built-in package (for example, "./cmd" getting
converted to "cmd"). Instead, the logic for ensuring that package
paths are canonical has been moved to okgo.