### PR TITLE
improvement: Bump to okgo v1.50.0 to use NewCreatorWithMultiCPU and denote errcheck errcheck.MultiCPU is true

### DIFF
--- a/changelog/@unreleased/pr-336.v2.yml
+++ b/changelog/@unreleased/pr-336.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Bump to okgo v1.50.0 to use NewCreatorWithMultiCPU and denote errcheck
+    errcheck.MultiCPU is true
+  links:
+  - https://github.com/palantir/godel-okgo-asset-errcheck/pull/336

--- a/errcheck/creator/creator.go
+++ b/errcheck/creator/creator.go
@@ -38,6 +38,7 @@ func Errcheck() checker.Creator {
 	return checker.NewCreator(
 		errcheck.TypeName,
 		errcheck.Priority,
+		errcheck.MultiCPU,
 		func(cfgYML []byte) (okgo.Checker, error) {
 			var cfg config.Errcheck
 			if err := yaml.UnmarshalStrict(cfgYML, &cfg); err != nil {

--- a/errcheck/creator/creator.go
+++ b/errcheck/creator/creator.go
@@ -35,7 +35,7 @@ import (
 var lineRegexp = regexp.MustCompile(`(.+):(\d+):(\d+):\t(.+)`)
 
 func Errcheck() checker.Creator {
-	return checker.NewCreator(
+	return checker.NewCreatorWithMultiCPU(
 		errcheck.TypeName,
 		errcheck.Priority,
 		errcheck.MultiCPU,

--- a/errcheck/errcheck.go
+++ b/errcheck/errcheck.go
@@ -21,6 +21,7 @@ import (
 const (
 	TypeName okgo.CheckerType     = "errcheck"
 	Priority okgo.CheckerPriority = 0
+	MultiCPU okgo.CheckerMultiCPU = true
 )
 
 type Checker struct {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/nmiyake/pkg/gofiles v1.2.0
 	github.com/palantir/amalgomate v1.38.0
 	github.com/palantir/godel/v2 v2.101.0
-	github.com/palantir/okgo v1.47.1-0.20240213232948-445b9ca64e33
+	github.com/palantir/okgo v1.47.1-0.20240213233635-8e7f44f047ba
 	github.com/palantir/pkg/cobracli v1.2.0
 	github.com/palantir/pkg/signals v1.1.0
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/nmiyake/pkg/gofiles v1.2.0
 	github.com/palantir/amalgomate v1.38.0
 	github.com/palantir/godel/v2 v2.101.0
-	github.com/palantir/okgo v1.47.1-0.20240213233635-8e7f44f047ba
+	github.com/palantir/okgo v1.50.0
 	github.com/palantir/pkg/cobracli v1.2.0
 	github.com/palantir/pkg/signals v1.1.0
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/nmiyake/pkg/gofiles v1.2.0
 	github.com/palantir/amalgomate v1.38.0
 	github.com/palantir/godel/v2 v2.101.0
-	github.com/palantir/okgo v1.47.0
+	github.com/palantir/okgo v1.47.1-0.20240213232948-445b9ca64e33
 	github.com/palantir/pkg/cobracli v1.2.0
 	github.com/palantir/pkg/signals v1.1.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/palantir/amalgomate v1.38.0 h1:hrOVNPig247ACXbIEQIHLoPmfMmC56eZxUYAUd
 github.com/palantir/amalgomate v1.38.0/go.mod h1:Gn9NWL63+1mCXIRcMVfZd8V51xfQq4gR/bLmlR4I7v4=
 github.com/palantir/godel/v2 v2.101.0 h1:5iF+av0TpeR0TX8kt06mz/9iQwudUYGFFtXmVG0EkaQ=
 github.com/palantir/godel/v2 v2.101.0/go.mod h1:/tkNvreQu//T5AtzDvHYCQUxLtJFM+2fTRAIMLl3ZX8=
-github.com/palantir/okgo v1.47.1-0.20240213232948-445b9ca64e33 h1:DdSokA90yTaMp5czvLte0RpgYIcDiB6fRzdQqOsJvjc=
-github.com/palantir/okgo v1.47.1-0.20240213232948-445b9ca64e33/go.mod h1:UwU5nQX7wiRoSL4zUf5YRztUvWTInbFIB0MEq/qo0Ik=
+github.com/palantir/okgo v1.47.1-0.20240213233635-8e7f44f047ba h1:Hz8PWTORiNGPUChYLVAo4igfEHLebC7dV+x8GDbMmwQ=
+github.com/palantir/okgo v1.47.1-0.20240213233635-8e7f44f047ba/go.mod h1:UwU5nQX7wiRoSL4zUf5YRztUvWTInbFIB0MEq/qo0Ik=
 github.com/palantir/pkg v1.1.0 h1:0EhrSUP8oeeh3MUvk7V/UU7WmsN1UiJNTvNj0sN9Cpo=
 github.com/palantir/pkg v1.1.0/go.mod h1:KC9srP/9ssWRxBxFCIqhUGC4Jt7OJkWRz0Iqehup1/c=
 github.com/palantir/pkg/cobracli v1.2.0 h1:hANp5fUB5cX90SVri97Apz4xB3BqnZw0gP2jMQ34G8Y=

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/palantir/amalgomate v1.38.0 h1:hrOVNPig247ACXbIEQIHLoPmfMmC56eZxUYAUd
 github.com/palantir/amalgomate v1.38.0/go.mod h1:Gn9NWL63+1mCXIRcMVfZd8V51xfQq4gR/bLmlR4I7v4=
 github.com/palantir/godel/v2 v2.101.0 h1:5iF+av0TpeR0TX8kt06mz/9iQwudUYGFFtXmVG0EkaQ=
 github.com/palantir/godel/v2 v2.101.0/go.mod h1:/tkNvreQu//T5AtzDvHYCQUxLtJFM+2fTRAIMLl3ZX8=
-github.com/palantir/okgo v1.47.0 h1:IhjJ7/VqWqZjqpeP0gcvbj9Prgtrw2jvMoRykkApvNA=
-github.com/palantir/okgo v1.47.0/go.mod h1:yFPEm36IoWxPRm3xVj7Ohh0/ZNcOnVGX684to/JnYJc=
+github.com/palantir/okgo v1.47.1-0.20240213232948-445b9ca64e33 h1:DdSokA90yTaMp5czvLte0RpgYIcDiB6fRzdQqOsJvjc=
+github.com/palantir/okgo v1.47.1-0.20240213232948-445b9ca64e33/go.mod h1:UwU5nQX7wiRoSL4zUf5YRztUvWTInbFIB0MEq/qo0Ik=
 github.com/palantir/pkg v1.1.0 h1:0EhrSUP8oeeh3MUvk7V/UU7WmsN1UiJNTvNj0sN9Cpo=
 github.com/palantir/pkg v1.1.0/go.mod h1:KC9srP/9ssWRxBxFCIqhUGC4Jt7OJkWRz0Iqehup1/c=
 github.com/palantir/pkg/cobracli v1.2.0 h1:hANp5fUB5cX90SVri97Apz4xB3BqnZw0gP2jMQ34G8Y=

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/palantir/amalgomate v1.38.0 h1:hrOVNPig247ACXbIEQIHLoPmfMmC56eZxUYAUd
 github.com/palantir/amalgomate v1.38.0/go.mod h1:Gn9NWL63+1mCXIRcMVfZd8V51xfQq4gR/bLmlR4I7v4=
 github.com/palantir/godel/v2 v2.101.0 h1:5iF+av0TpeR0TX8kt06mz/9iQwudUYGFFtXmVG0EkaQ=
 github.com/palantir/godel/v2 v2.101.0/go.mod h1:/tkNvreQu//T5AtzDvHYCQUxLtJFM+2fTRAIMLl3ZX8=
-github.com/palantir/okgo v1.47.1-0.20240213233635-8e7f44f047ba h1:Hz8PWTORiNGPUChYLVAo4igfEHLebC7dV+x8GDbMmwQ=
-github.com/palantir/okgo v1.47.1-0.20240213233635-8e7f44f047ba/go.mod h1:UwU5nQX7wiRoSL4zUf5YRztUvWTInbFIB0MEq/qo0Ik=
+github.com/palantir/okgo v1.50.0 h1:U/oH1UmTEySEF7xt7aOBzTM1T0zCz13fi2TAxmRQWgQ=
+github.com/palantir/okgo v1.50.0/go.mod h1:UwU5nQX7wiRoSL4zUf5YRztUvWTInbFIB0MEq/qo0Ik=
 github.com/palantir/pkg v1.1.0 h1:0EhrSUP8oeeh3MUvk7V/UU7WmsN1UiJNTvNj0sN9Cpo=
 github.com/palantir/pkg v1.1.0/go.mod h1:KC9srP/9ssWRxBxFCIqhUGC4Jt7OJkWRz0Iqehup1/c=
 github.com/palantir/pkg/cobracli v1.2.0 h1:hANp5fUB5cX90SVri97Apz4xB3BqnZw0gP2jMQ34G8Y=

--- a/vendor/github.com/palantir/okgo/checker/amalgomated_helpers.go
+++ b/vendor/github.com/palantir/okgo/checker/amalgomated_helpers.go
@@ -42,6 +42,12 @@ func ParamPriority(priority okgo.CheckerPriority) AmalgomatedCheckerParam {
 	})
 }
 
+func ParamMultiCPU(multiCPU okgo.CheckerMultiCPU) AmalgomatedCheckerParam {
+	return paramFunc(func(c *amalgomatedChecker) {
+		c.multiCPU = multiCPU
+	})
+}
+
 func ParamLineParserWithWd(lineParserWithWd func(line, wd string) okgo.Issue) AmalgomatedCheckerParam {
 	return paramFunc(func(c *amalgomatedChecker) {
 		c.lineParserWithWd = lineParserWithWd
@@ -77,6 +83,7 @@ func NewAmalgomatedChecker(typeName okgo.CheckerType, params ...AmalgomatedCheck
 type amalgomatedChecker struct {
 	typeName              okgo.CheckerType
 	priority              okgo.CheckerPriority
+	multiCPU              okgo.CheckerMultiCPU
 	lineParserWithWd      func(line, wd string) okgo.Issue
 	includeProjectDirFlag bool
 	args                  []string
@@ -88,6 +95,10 @@ func (c *amalgomatedChecker) Type() (okgo.CheckerType, error) {
 
 func (c *amalgomatedChecker) Priority() (okgo.CheckerPriority, error) {
 	return c.priority, nil
+}
+
+func (c *amalgomatedChecker) MultiCPU() (okgo.CheckerMultiCPU, error) {
+	return c.multiCPU, nil
 }
 
 func (c *amalgomatedChecker) Check(pkgPaths []string, projectDir string, stdout io.Writer) {

--- a/vendor/github.com/palantir/okgo/checker/assetapi.go
+++ b/vendor/github.com/palantir/okgo/checker/assetapi.go
@@ -34,6 +34,7 @@ func AssetRootCmd(creator Creator, upgradeConfigFn pluginapi.UpgradeConfigFn, sh
 	creatorFn := creator.Creator()
 	rootCmd.AddCommand(newTypeCmd(checkerType))
 	rootCmd.AddCommand(newPriorityCmd(creator.Priority()))
+	rootCmd.AddCommand(newMultiCPUCmd(creator.MultiCPU()))
 	rootCmd.AddCommand(newVerifyConfigCmd(creatorFn))
 	rootCmd.AddCommand(newCheckCmd(creatorFn))
 	rootCmd.AddCommand(newRunCheckCmdCmd(creatorFn))
@@ -67,6 +68,23 @@ func newPriorityCmd(priority okgo.CheckerPriority) *cobra.Command {
 		Short: "Print the priority of the checker",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputJSON, err := json.Marshal(priority)
+			if err != nil {
+				return errors.Wrapf(err, "failed to marshal output as JSON")
+			}
+			cmd.Print(string(outputJSON))
+			return nil
+		},
+	}
+}
+
+const multiCPUCmdName = "multicpu"
+
+func newMultiCPUCmd(cpu okgo.CheckerMultiCPU) *cobra.Command {
+	return &cobra.Command{
+		Use:   multiCPUCmdName,
+		Short: "Print is the check command uses multiple cpus",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputJSON, err := json.Marshal(cpu)
 			if err != nil {
 				return errors.Wrapf(err, "failed to marshal output as JSON")
 			}

--- a/vendor/github.com/palantir/okgo/checker/assetapi.go
+++ b/vendor/github.com/palantir/okgo/checker/assetapi.go
@@ -82,7 +82,7 @@ const multiCPUCmdName = "multicpu"
 func newMultiCPUCmd(cpu okgo.CheckerMultiCPU) *cobra.Command {
 	return &cobra.Command{
 		Use:   multiCPUCmdName,
-		Short: "Print is the check command uses multiple cpus",
+		Short: "Print whether the check uses multiple CPUs",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputJSON, err := json.Marshal(cpu)
 			if err != nil {

--- a/vendor/github.com/palantir/okgo/checker/checker_asset.go
+++ b/vendor/github.com/palantir/okgo/checker/checker_asset.go
@@ -30,6 +30,7 @@ type assetChecker struct {
 	cfgYML          string
 	checkerType     okgo.CheckerType
 	checkerPriority okgo.CheckerPriority
+	checkerMultiCPU okgo.CheckerMultiCPU
 }
 
 func (c *assetChecker) Type() (okgo.CheckerType, error) {
@@ -38,6 +39,10 @@ func (c *assetChecker) Type() (okgo.CheckerType, error) {
 
 func (c *assetChecker) Priority() (okgo.CheckerPriority, error) {
 	return c.checkerPriority, nil
+}
+
+func (c *assetChecker) MultiCPU() (okgo.CheckerMultiCPU, error) {
+	return c.checkerMultiCPU, nil
 }
 
 func (c *assetChecker) VerifyConfig() error {

--- a/vendor/github.com/palantir/okgo/checker/checkers.go
+++ b/vendor/github.com/palantir/okgo/checker/checkers.go
@@ -61,7 +61,11 @@ func (c *creatorStruct) Creator() CreatorFunction {
 	return c.creator
 }
 
-func NewCreator(
+func NewCreator(checkerType okgo.CheckerType, priority okgo.CheckerPriority, creatorFn CreatorFunction) Creator {
+	return NewCreatorWithMultiCPU(checkerType, priority, false, creatorFn)
+}
+
+func NewCreatorWithMultiCPU(
 	checkerType okgo.CheckerType,
 	priority okgo.CheckerPriority,
 	multiCPU okgo.CheckerMultiCPU,
@@ -89,7 +93,7 @@ func AssetCheckerCreators(assetPaths ...string) ([]Creator, []okgo.ConfigUpgrade
 		checkerPriority := checkerMetadata.checkerPriority
 		checkerMultiCPU := checkerMetadata.checkerMultiCPU
 		checkerTypeToAssets[checkerType] = append(checkerTypeToAssets[checkerType], currAssetPath)
-		checkerCreators = append(checkerCreators, NewCreator(checkerType, checkerPriority, checkerMultiCPU,
+		checkerCreators = append(checkerCreators, NewCreatorWithMultiCPU(checkerType, checkerPriority, checkerMultiCPU,
 			func(cfgYML []byte) (okgo.Checker, error) {
 				newChecker := assetChecker{
 					assetPath:       currAssetPath,

--- a/vendor/github.com/palantir/okgo/checker/checkers.go
+++ b/vendor/github.com/palantir/okgo/checker/checkers.go
@@ -34,12 +34,14 @@ type CreatorFunction func(cfgYML []byte) (okgo.Checker, error)
 type Creator interface {
 	Type() okgo.CheckerType
 	Priority() okgo.CheckerPriority
+	MultiCPU() okgo.CheckerMultiCPU
 	Creator() CreatorFunction
 }
 
 type creatorStruct struct {
 	checkerType okgo.CheckerType
 	priority    okgo.CheckerPriority
+	multiCPU    okgo.CheckerMultiCPU
 	creator     CreatorFunction
 }
 
@@ -51,14 +53,23 @@ func (c *creatorStruct) Priority() okgo.CheckerPriority {
 	return c.priority
 }
 
+func (c *creatorStruct) MultiCPU() okgo.CheckerMultiCPU {
+	return c.multiCPU
+}
+
 func (c *creatorStruct) Creator() CreatorFunction {
 	return c.creator
 }
 
-func NewCreator(checkerType okgo.CheckerType, priority okgo.CheckerPriority, creatorFn CreatorFunction) Creator {
+func NewCreator(
+	checkerType okgo.CheckerType,
+	priority okgo.CheckerPriority,
+	multiCPU okgo.CheckerMultiCPU,
+	creatorFn CreatorFunction) Creator {
 	return &creatorStruct{
 		checkerType: checkerType,
 		priority:    priority,
+		multiCPU:    multiCPU,
 		creator:     creatorFn,
 	}
 }
@@ -73,17 +84,19 @@ func AssetCheckerCreators(assetPaths ...string) ([]Creator, []okgo.ConfigUpgrade
 	}
 	for _, currAssetPath := range assetPaths {
 		currAssetPath := currAssetPath
-		typeAndPriority := typeAndPriorities[currAssetPath]
-		checkerType := typeAndPriority.checkerType
-		checkerPriority := typeAndPriority.checkerPriority
+		checkerMetadata := typeAndPriorities[currAssetPath]
+		checkerType := checkerMetadata.checkerType
+		checkerPriority := checkerMetadata.checkerPriority
+		checkerMultiCPU := checkerMetadata.checkerMultiCPU
 		checkerTypeToAssets[checkerType] = append(checkerTypeToAssets[checkerType], currAssetPath)
-		checkerCreators = append(checkerCreators, NewCreator(checkerType, checkerPriority,
+		checkerCreators = append(checkerCreators, NewCreator(checkerType, checkerPriority, checkerMultiCPU,
 			func(cfgYML []byte) (okgo.Checker, error) {
 				newChecker := assetChecker{
 					assetPath:       currAssetPath,
 					cfgYML:          string(cfgYML),
 					checkerType:     checkerType,
 					checkerPriority: checkerPriority,
+					checkerMultiCPU: checkerMultiCPU,
 				}
 				if err := newChecker.VerifyConfig(); err != nil {
 					return nil, err
@@ -110,13 +123,14 @@ func AssetCheckerCreators(assetPaths ...string) ([]Creator, []okgo.ConfigUpgrade
 	return checkerCreators, configUpgraders, nil
 }
 
-type typeAndPriority struct {
+type checkerMetadata struct {
 	checkerType     okgo.CheckerType
 	checkerPriority okgo.CheckerPriority
+	checkerMultiCPU okgo.CheckerMultiCPU
 }
 
-func determineTypeAndPriorityForPaths(assetPaths []string) (map[string]typeAndPriority, error) {
-	typeAndPriorities := make(map[string]typeAndPriority)
+func determineTypeAndPriorityForPaths(assetPaths []string) (map[string]checkerMetadata, error) {
+	typeAndPriorities := make(map[string]checkerMetadata)
 	var (
 		mapLock sync.Mutex
 		g       errgroup.Group
@@ -140,28 +154,29 @@ func determineTypeAndPriorityForPaths(assetPaths []string) (map[string]typeAndPr
 	return typeAndPriorities, nil
 }
 
-func determineTypeAndPriority(assetPath string) (typeAndPriority, error) {
+func determineTypeAndPriority(assetPath string) (checkerMetadata, error) {
 	nameCmd := exec.Command(assetPath, typeCmdName)
 	outputBytes, err := runCommand(nameCmd)
 	if err != nil {
-		return typeAndPriority{}, err
+		return checkerMetadata{}, err
 	}
 	var checkerType okgo.CheckerType
 	if err := json.Unmarshal(outputBytes, &checkerType); err != nil {
-		return typeAndPriority{}, errors.Wrapf(err, "failed to unmarshal JSON")
+		return checkerMetadata{}, errors.Wrapf(err, "failed to unmarshal JSON")
 	}
 	priorityCmd := exec.Command(assetPath, priorityCmdName)
 	outputBytes, err = runCommand(priorityCmd)
 	if err != nil {
-		return typeAndPriority{}, err
+		return checkerMetadata{}, err
 	}
 	var checkerPriority okgo.CheckerPriority
 	if err := json.Unmarshal(outputBytes, &checkerPriority); err != nil {
-		return typeAndPriority{}, errors.Wrapf(err, "failed to unmarshal JSON")
+		return checkerMetadata{}, errors.Wrapf(err, "failed to unmarshal JSON")
 	}
-	return typeAndPriority{
+	return checkerMetadata{
 		checkerType:     checkerType,
 		checkerPriority: checkerPriority,
+		checkerMultiCPU: false,
 	}, nil
 }
 

--- a/vendor/github.com/palantir/okgo/okgo/checker.go
+++ b/vendor/github.com/palantir/okgo/okgo/checker.go
@@ -36,7 +36,7 @@ type Checker interface {
 	// Priority returns the priority of the check. A lower number indicates a higher priority (will be run earlier).
 	Priority() (CheckerPriority, error)
 
-	// MultiCPU returns if the check uses multiple CPUs  in its check command
+	// MultiCPU returns if the check uses multiple CPUs in its check command
 	MultiCPU() (CheckerMultiCPU, error)
 
 	// Check runs the check on the specified packages and writes the output to the provided io.Writer. All output

--- a/vendor/github.com/palantir/okgo/okgo/checker.go
+++ b/vendor/github.com/palantir/okgo/okgo/checker.go
@@ -27,12 +27,17 @@ import (
 
 type CheckerPriority int
 
+type CheckerMultiCPU bool
+
 type Checker interface {
 	// Type returns the type of this Checker.
 	Type() (CheckerType, error)
 
 	// Priority returns the priority of the check. A lower number indicates a higher priority (will be run earlier).
 	Priority() (CheckerPriority, error)
+
+	// MultiCPU returns if the check uses multiple CPUs  in its check command
+	MultiCPU() (CheckerMultiCPU, error)
 
 	// Check runs the check on the specified packages and writes the output to the provided io.Writer. All output
 	// written to the writer must be the JSON-serialized form of Issue, where there is one issue per line. Note that

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -100,7 +100,7 @@ github.com/palantir/godel/v2/godelgetter
 github.com/palantir/godel/v2/pkg/osarch
 github.com/palantir/godel/v2/pkg/products
 github.com/palantir/godel/v2/pkg/versionedconfig
-# github.com/palantir/okgo v1.47.1-0.20240213233635-8e7f44f047ba
+# github.com/palantir/okgo v1.50.0
 ## explicit; go 1.21
 github.com/palantir/okgo/checker
 github.com/palantir/okgo/okgo

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -100,7 +100,7 @@ github.com/palantir/godel/v2/godelgetter
 github.com/palantir/godel/v2/pkg/osarch
 github.com/palantir/godel/v2/pkg/products
 github.com/palantir/godel/v2/pkg/versionedconfig
-# github.com/palantir/okgo v1.47.1-0.20240213232948-445b9ca64e33
+# github.com/palantir/okgo v1.47.1-0.20240213233635-8e7f44f047ba
 ## explicit; go 1.21
 github.com/palantir/okgo/checker
 github.com/palantir/okgo/okgo

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -100,7 +100,7 @@ github.com/palantir/godel/v2/godelgetter
 github.com/palantir/godel/v2/pkg/osarch
 github.com/palantir/godel/v2/pkg/products
 github.com/palantir/godel/v2/pkg/versionedconfig
-# github.com/palantir/okgo v1.47.0
+# github.com/palantir/okgo v1.47.1-0.20240213232948-445b9ca64e33
 ## explicit; go 1.21
 github.com/palantir/okgo/checker
 github.com/palantir/okgo/okgo


### PR DESCRIPTION
- Bump to okgo v1.50.0 to use NewCreatorWithMultiCPU and denote errcheck errcheck.MultiCPU is true
- To help handle https://github.com/palantir/okgo/issues/339

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

